### PR TITLE
Add support for configuring resource requests and limits

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -11,6 +11,30 @@ parameters:
             secretKeyRef:
               name: xelon-csi
               key: api-token
+      resources:
+        xelon-csi-plugin:
+          requests:
+            cpu: 2m
+            memory: 20Mi
+        csi-attacher:
+          requests:
+            cpu: 2m
+            memory: 20Mi
+        csi-provisioner:
+          requests:
+            cpu: 2m
+            memory: 20Mi
+
+    csi_driver:
+      resources:
+        xelon-csi-plugin:
+          requests:
+            cpu: 2m
+            memory: 20Mi
+        csi-node-driver-registrar:
+          requests:
+            cpu: 2m
+            memory: 20Mi
 
     secrets:
       xelon-csi:

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -65,6 +65,7 @@ local fixupStorageClasses = {
 };
 
 local fixupControllerConfig = {
+  local resources(name) = std.get(params.controller.resources, name),
   assert std.length(super.statefulset) == 1,
   statefulset: [
     sts {
@@ -74,6 +75,8 @@ local fixupControllerConfig = {
             containers: [
               c {
                 imagePullPolicy: 'IfNotPresent',
+                [if resources(c.name) != null then 'resources']:
+                  std.prune(resources(c.name)),
                 env: std.filter(
                   function(it) it != null,
                   [
@@ -105,6 +108,7 @@ local fixupControllerConfig = {
 };
 
 local fixupCsiDriverConfig = {
+  local resources(name) = std.get(params.csi_driver.resources, name),
   daemonset: [
     ds {
       spec+: {
@@ -112,6 +116,8 @@ local fixupCsiDriverConfig = {
           spec+: {
             containers: [
               c {
+                [if resources(c.name) != null then 'resources']:
+                  std.prune(resources(c.name)),
                 imagePullPolicy: 'IfNotPresent',
               }
               for c in super.containers

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -64,6 +64,32 @@ env:
 <1> The provided string value is used as the value for field `value` of the entry in the `env` array.
 <2> The provided object value is used as-is for the entry in the `env` array.
 
+=== `controller.resources`
+
+[horizontal]
+type:: dict
+defaults:: https://github.com/projectsyn/component-xelon-csi/blob/master/class/defaults.yml[See `class/defaults.yml`]
+
+This parameter allows users to configure the CSI controller's resource requests and limits.
+Currently, the component only sets resource requests.
+
+If desired, a container's resource requests and limits can be completely cleared by setting the container's parameter value to `null`.
+
+== `csi_driver`
+
+This parameter holds configurations for the CSI driver daemonset.
+
+=== `csi_driver.resources`
+
+[horizontal]
+type:: dict
+defaults:: https://github.com/projectsyn/component-xelon-csi/blob/master/class/defaults.yml[See `class/defaults.yml`]
+
+This parameter allows users to configure the CSI driver pods' resource requests and limits.
+Currently, the component only sets resource requests.
+
+If desired, a container's resource requests and limits can be completely cleared by setting the container's parameter value to `null`.
+
 == `secrets`
 
 [horizontal]

--- a/tests/golden/defaults/xelon-csi/xelon-csi/daemonset.yaml
+++ b/tests/golden/defaults/xelon-csi/xelon-csi/daemonset.yaml
@@ -19,6 +19,10 @@ spec:
           image: xelonag/xelon-csi:v0.5.0
           imagePullPolicy: IfNotPresent
           name: xelon-csi-plugin
+          resources:
+            requests:
+              cpu: 2m
+              memory: 20Mi
           securityContext:
             allowPrivilegeEscalation: true
             capabilities:
@@ -52,6 +56,10 @@ spec:
           image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
           imagePullPolicy: IfNotPresent
           name: csi-node-driver-registrar
+          resources:
+            requests:
+              cpu: 2m
+              memory: 20Mi
           volumeMounts:
             - mountPath: /csi/
               name: plugin-dir

--- a/tests/golden/defaults/xelon-csi/xelon-csi/statefulset.yaml
+++ b/tests/golden/defaults/xelon-csi/xelon-csi/statefulset.yaml
@@ -34,6 +34,10 @@ spec:
           image: xelonag/xelon-csi:v0.5.0
           imagePullPolicy: IfNotPresent
           name: xelon-csi-plugin
+          resources:
+            requests:
+              cpu: 2m
+              memory: 20Mi
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
@@ -52,6 +56,10 @@ spec:
           image: k8s.gcr.io/sig-storage/csi-provisioner:v2.0.2
           imagePullPolicy: IfNotPresent
           name: csi-provisioner
+          resources:
+            requests:
+              cpu: 2m
+              memory: 20Mi
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
@@ -64,6 +72,10 @@ spec:
           image: k8s.gcr.io/sig-storage/csi-attacher:v3.1.0
           imagePullPolicy: IfNotPresent
           name: csi-attacher
+          resources:
+            requests:
+              cpu: 2m
+              memory: 20Mi
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir

--- a/tests/golden/openshift/xelon-csi/xelon-csi/daemonset.yaml
+++ b/tests/golden/openshift/xelon-csi/xelon-csi/daemonset.yaml
@@ -19,6 +19,10 @@ spec:
           image: xelonag/xelon-csi:v0.5.0
           imagePullPolicy: IfNotPresent
           name: xelon-csi-plugin
+          resources:
+            requests:
+              cpu: 2m
+              memory: 20Mi
           securityContext:
             allowPrivilegeEscalation: true
             capabilities:
@@ -52,6 +56,10 @@ spec:
           image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
           imagePullPolicy: IfNotPresent
           name: csi-node-driver-registrar
+          resources:
+            requests:
+              cpu: 2m
+              memory: 20Mi
           volumeMounts:
             - mountPath: /csi/
               name: plugin-dir

--- a/tests/golden/openshift/xelon-csi/xelon-csi/statefulset.yaml
+++ b/tests/golden/openshift/xelon-csi/xelon-csi/statefulset.yaml
@@ -34,6 +34,10 @@ spec:
           image: xelonag/xelon-csi:v0.5.0
           imagePullPolicy: IfNotPresent
           name: xelon-csi-plugin
+          resources:
+            requests:
+              cpu: 2m
+              memory: 20Mi
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
@@ -52,6 +56,10 @@ spec:
           image: k8s.gcr.io/sig-storage/csi-provisioner:v2.0.2
           imagePullPolicy: IfNotPresent
           name: csi-provisioner
+          resources:
+            requests:
+              cpu: 2m
+              memory: 20Mi
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
@@ -64,6 +72,10 @@ spec:
           image: k8s.gcr.io/sig-storage/csi-attacher:v3.1.0
           imagePullPolicy: IfNotPresent
           name: csi-attacher
+          resources:
+            requests:
+              cpu: 2m
+              memory: 20Mi
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir


### PR DESCRIPTION
This commit adds new parameters `controller.resources` and `csi_driver.resources` which can be used to configure resource requests and limits for each controller and CSI driver container.

We set fairly optimistic resource requests (currently container memory consumption is between 15 and 25Mi), and no limits. With this configuration, the pods won't be arbitrarily restarted due to memory limits, and the scheduler has some information to work with.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
