### PR TITLE
Configure renovate to update the defaults.yaml dependencies

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -2,6 +2,7 @@ parameters:
   xelon_csi:
     =_metadata: {}
     namespace: syn-xelon-csi
+    # renovate: datasource=github-releases depName=Xelon-AG/xelon-csi
     manifests_version: v0.5.0
     controller:
       env:

--- a/renovate.json
+++ b/renovate.json
@@ -14,5 +14,13 @@
   "suppressNotifications": [ "artifactErrors" ],
   "labels": [
     "dependency"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["variables\\/defaults\\.yaml"],
+      "matchStrings": [
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?_version:(?<currentValue>.*)"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Allows to automatically detect, if an new GitHub release of
the Xelon CSI driver has been released.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

