### PR TITLE
Fix renovate regexManager versioningTemplate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,8 @@
       "fileMatch": ["variables\\/defaults\\.yaml"],
       "matchStrings": [
         "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?_version:(?<currentValue>.*)"
-      ]
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }
   ]
 }


### PR DESCRIPTION
Because the regex string captures the versioning, the versioningTemplate need to be configured according the example.

Ref: https://docs.renovatebot.com/modules/manager/regex/#advanced-capture

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
