### PR TITLE
Make metadata-file directory mounted by the CSI driver configurable

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -32,6 +32,7 @@ parameters:
             memory: 20Mi
 
     csi_driver:
+      metadata_directory: /etc/init.d
       resources:
         xelon-csi-plugin:
           requests:

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -120,6 +120,17 @@ local fixupCsiDriverConfig = {
               }
               for c in super.containers
             ],
+            volumes: [
+              if v.name == 'metadata-file' then
+                v {
+                  hostPath: {
+                    path: params.csi_driver.metadata_directory,
+                  },
+                }
+              else
+                v
+              for v in super.volumes
+            ],
           },
         },
       },

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -89,6 +89,14 @@ If desired, a container's resource requests and limits can be completely cleared
 
 This parameter holds configurations for the CSI driver daemonset.
 
+=== `csi_driver.metadata_directory`
+
+[horizontal]
+type:: string
+default:: `/etc/init.d`
+
+This parameter allows users to configure which host path the CSI driver daemonset mounts to expose the Xelon AG `metadata.json` to the CSI driver.
+
 === `csi_driver.resources`
 
 [horizontal]

--- a/tests/golden/openshift/xelon-csi/xelon-csi/daemonset.yaml
+++ b/tests/golden/openshift/xelon-csi/xelon-csi/daemonset.yaml
@@ -84,5 +84,5 @@ spec:
             path: /dev
           name: device-dir
         - hostPath:
-            path: /etc/init.d
+            path: /etc/rc.d/init.d
           name: metadata-file

--- a/tests/openshift.yml
+++ b/tests/openshift.yml
@@ -13,3 +13,7 @@ parameters:
 
   facts:
     distribution: openshift4
+
+  xelon_csi:
+    csi_driver:
+      metadata_directory: /etc/rc.d/init.d


### PR DESCRIPTION
We need this on OpenShift 4.13, where `/etc/init.d` doesn't exist anymore.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
