### PR TITLE
Fix compilation after upstream manifest changes

### DIFF
--- a/class/xelon-csi.yml
+++ b/class/xelon-csi.yml
@@ -2,7 +2,7 @@ parameters:
   kapitan:
     dependencies:
       - type: https
-        source: https://raw.githubusercontent.com/Xelon-AG/xelon-csi/master/deploy/kubernetes/releases/xelon-csi-${xelon_csi:manifests_version}/driver.yml
+        source: https://raw.githubusercontent.com/Xelon-AG/xelon-csi/${xelon_csi:manifests_version}/deploy/kubernetes/releases/xelon-csi-${xelon_csi:manifests_version}/driver.yml
         output_path: ${_base_directory}/manifests/${xelon_csi:manifests_version}/driver.yaml
     compile:
       - input_paths:


### PR DESCRIPTION
https://github.com/Xelon-AG/xelon-csi/pull/27 removed all versioned manifests.

This is a quickfix which most likely won't work with future releases.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
