### PR TITLE
Fix xelon-api secret format

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -45,7 +45,7 @@ parameters:
             memory: 20Mi
 
     secrets:
-      xelon-csi:
+      xelon-api-credentials:
         stringData:
-          api-token: ?{vaultkv:${cluster:tenant}/${cluster:name}/xelon/csi-driver/api-token}
-          client-id: ?{vaultkv:${cluster:tenant}/${cluster:name}/xelon/csi-driver/client-id}
+          token: ?{vaultkv:${cluster:tenant}/${cluster:name}/xelon/csi-driver/api-token}
+          cloudId: ?{vaultkv:${cluster:tenant}/${cluster:name}/xelon/csi-driver/client-id}

--- a/tests/golden/defaults/xelon-csi/xelon-csi/02_secrets.yaml
+++ b/tests/golden/defaults/xelon-csi/xelon-csi/02_secrets.yaml
@@ -3,9 +3,9 @@ kind: Secret
 metadata:
   annotations: {}
   labels:
-    name: xelon-csi
-  name: xelon-csi
+    name: xelon-api-credentials
+  name: xelon-api-credentials
 stringData:
-  api-token: t-silent-test-1234/c-green-test-1234/xelon/csi-driver/api-token
-  client-id: t-silent-test-1234/c-green-test-1234/xelon/csi-driver/client-id
+  cloudId: t-silent-test-1234/c-green-test-1234/xelon/csi-driver/client-id
+  token: t-silent-test-1234/c-green-test-1234/xelon/csi-driver/api-token
 type: Opaque

--- a/tests/golden/openshift/xelon-csi/xelon-csi/02_secrets.yaml
+++ b/tests/golden/openshift/xelon-csi/xelon-csi/02_secrets.yaml
@@ -3,9 +3,9 @@ kind: Secret
 metadata:
   annotations: {}
   labels:
-    name: xelon-csi
-  name: xelon-csi
+    name: xelon-api-credentials
+  name: xelon-api-credentials
 stringData:
-  api-token: t-silent-test-1234/c-green-test-1234/xelon/csi-driver/api-token
-  client-id: t-silent-test-1234/c-green-test-1234/xelon/csi-driver/client-id
+  cloudId: t-silent-test-1234/c-green-test-1234/xelon/csi-driver/client-id
+  token: t-silent-test-1234/c-green-test-1234/xelon/csi-driver/api-token
 type: Opaque


### PR DESCRIPTION
The new controller version needs the secret with another name and format.




## Checklist

- [ ] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
